### PR TITLE
Use *this instead of this in sigc::mem_fun

### DIFF
--- a/src/main-view_impl.cxx
+++ b/src/main-view_impl.cxx
@@ -25,28 +25,28 @@ MainViewImpl::MainViewImpl (
 
   builder->get_widget ("main-window", m_window);
   m_window->signal_hide ().connect
-    (sigc::mem_fun (this, &MainViewImpl::cb_on_close));
+    (sigc::mem_fun (*this, &MainViewImpl::cb_on_close));
 
   Gtk::MenuItem * menuitem;
   builder->get_widget ("menu-file-new", menuitem);
   menuitem->signal_activate ().connect
-    (sigc::mem_fun (this, &MainViewImpl::cb_on_file_new));
+    (sigc::mem_fun (*this, &MainViewImpl::cb_on_file_new));
 
   builder->get_widget ("menu-file-open", menuitem);
   menuitem->signal_activate ().connect
-    (sigc::mem_fun (this, &MainViewImpl::cb_on_file_open));
+    (sigc::mem_fun (*this, &MainViewImpl::cb_on_file_open));
 
   builder->get_widget ("menu-file-save", menuitem);
   menuitem->signal_activate ().connect
-    (sigc::mem_fun (this, &MainViewImpl::cb_on_file_save));
+    (sigc::mem_fun (*this, &MainViewImpl::cb_on_file_save));
 
   builder->get_widget ("menu-file-save-as", menuitem);
   menuitem->signal_activate ().connect
-    (sigc::mem_fun (this, &MainViewImpl::cb_on_file_save_as));
+    (sigc::mem_fun (*this, &MainViewImpl::cb_on_file_save_as));
 
   builder->get_widget ("menu-file-quit", menuitem);
   menuitem->signal_activate ().connect
-    (sigc::mem_fun (this, &MainViewImpl::cb_on_close));
+    (sigc::mem_fun (*this, &MainViewImpl::cb_on_close));
 
   m_window->set_title ("Untitled");
 }

--- a/src/wbs-view_impl.cxx
+++ b/src/wbs-view_impl.cxx
@@ -106,16 +106,16 @@ WBSViewImpl::WBSViewImpl (
   m_tree_view.append_column_editable ("Effort", m_cols.effort);
 
   m_tree_view.signal_button_press_event ().connect_notify
-    (sigc::mem_fun (this, &WBSViewImpl::cb_on_button_pressed));
+    (sigc::mem_fun (*this, &WBSViewImpl::cb_on_button_pressed));
   m_tree_view.signal_row_activated ().connect
-    (sigc::mem_fun (this, &WBSViewImpl::cb_on_row_activated));
+    (sigc::mem_fun (*this, &WBSViewImpl::cb_on_row_activated));
 
   m_tree_store->signal_row_changed ().connect (
-    sigc::mem_fun (this, &WBSViewImpl::cb_on_row_changed));
+    sigc::mem_fun (*this, &WBSViewImpl::cb_on_row_changed));
 
   m_tree_selection = m_tree_view.get_selection ();
   m_tree_selection->signal_changed ().connect
-    (sigc::mem_fun (this, &WBSViewImpl::cb_on_row_selected));
+    (sigc::mem_fun (*this, &WBSViewImpl::cb_on_row_selected));
 
   Gtk::ScrolledWindow * tree_container = nullptr;
   builder->get_widget ("tree-container", tree_container);


### PR DESCRIPTION
Passing pointer to sigc::mem_fun is deprecated and might be removed in future. So, it is better to fix it now.

reference: https://www.murrayc.com/permalink/2016/03/17/libsigc-stdfunction-style-syntax/

previous pull at: https://github.com/froyg/thittam/pull/19