### PR TITLE
Unindent task in wbs

### DIFF
--- a/src/task.cxx
+++ b/src/task.cxx
@@ -87,6 +87,7 @@ void
 Task::unindent_child (size_t index, size_t parent_index)
 {
   assert (m_parent != nullptr);
+
   auto new_parent = m_parent;
   auto raw_it = m_children_raw.begin () + index;
   auto owned_it = m_children_owned.begin () + index;
@@ -121,28 +122,10 @@ Task::dump (void)
 void
 Task::recompute_id_of_children (size_t start_index)
 {
-  auto begin_it = m_children_raw.begin () + start_index;
-  auto index = start_index;
-  for (auto it = begin_it; it != m_children_raw.end (); ++it)
+  m_id = compute_child_id (start_index);
+  for (size_t i = start_index; i < m_children_raw.size (); ++i)
   {
-    recompute_id_of_tree (*it, index);
-    index += 1;
-  }
-}
-
-void
-Task::recompute_id_of_tree (Task * task, size_t index)
-{
-  task->m_id = compute_child_id (index);
-
-  if (task->has_children ())
-  {
-    size_t child_index = 0;
-    for (auto child : m_children_raw)
-    {
-      recompute_id_of_tree (child, child_index);
-      child_index += 1;
-    }
+    m_children_raw[i]->recompute_id_of_children ();
   }
 }
 

--- a/src/task.cxx
+++ b/src/task.cxx
@@ -83,6 +83,22 @@ Task::indent_child (size_t index)
   new_parent->add_child (std::move (task));
 }
 
+void
+Task::unindent_child (size_t index, size_t parent_index)
+{
+  assert (m_parent != nullptr);
+  auto new_parent = m_parent;
+  auto raw_it = m_children_raw.begin () + index;
+  auto owned_it = m_children_owned.begin () + index;
+
+  auto task = std::move (*owned_it);
+
+  m_children_raw.erase (raw_it);
+  m_children_owned.erase (owned_it);
+
+  new_parent->add_child_after (parent_index, std::move (task));
+}
+
 boost::property_tree::ptree
 Task::dump (void)
 {

--- a/src/task.h
+++ b/src/task.h
@@ -95,6 +95,7 @@ public:
   void add_child_after (size_t index, std::unique_ptr<Task> && task);
   void remove_child (size_t index);
   void indent_child (size_t index);
+  void unindent_child (size_t index, size_t parent_index);
 
   boost::property_tree::ptree dump (void);
 

--- a/src/task.h
+++ b/src/task.h
@@ -100,8 +100,7 @@ public:
   boost::property_tree::ptree dump (void);
 
 private:
-  void recompute_id_of_children (size_t start_index);
-  void recompute_id_of_tree (Task * task, size_t index);
+  void recompute_id_of_children (size_t start_index = 0);
   std::string compute_child_id (int number) const;
 
 private:

--- a/src/wbs-controller_impl.cxx
+++ b/src/wbs-controller_impl.cxx
@@ -96,19 +96,21 @@ WBSControllerImpl::view_indent_clicked (void)
 void
 WBSControllerImpl::view_unindent_clicked (void)
 {
-  Log_I << "[WBSControllerImpl] Unindent";
+  auto path = m_selected_path;
 
-  assert (m_selected_path.parts_length() != 0);
-  if (m_selected_path.parts_length() < 2)
+  assert (path.parts_length() != 0);
+  if (path.parts_length() < 2)
   {
     // TODO: Put this message in status bar of thittam
     Log_I << "Can't unindent level 1 task";
     return;
   }
 
-  m_view->unindent(m_selected_path);
+  m_view->unindent(path);
 
   m_view->renumber();
+
+  m_wbs->unindent (path);
 }
 
 void

--- a/src/wbs-view_impl.cxx
+++ b/src/wbs-view_impl.cxx
@@ -242,14 +242,12 @@ WBSViewImpl::add_sibling (const WBS::Path & t_path)
   auto it = m_tree_store->get_iter (g_path);
   if (t_path.parts_length() != 0)
   {
-    auto child = m_tree_store->insert_after (it->children());
+    m_tree_store->insert_after (it->children());
   }
   else
   {
-    auto child = m_tree_store->append ();
+    m_tree_store->append ();
   }
-  // auto & row = *child;
-  // row[m_cols.id] = "aa";
   Log_D << "g_path " << g_path.size ();
 }
 

--- a/src/wbs.h
+++ b/src/wbs.h
@@ -30,6 +30,7 @@ public:
   virtual void add_child (const Path & parent_path) = 0;
   virtual void add_sibling (const Path & path) = 0;
   virtual void indent (const Path & path) = 0;
+  virtual void unindent (const Path & path) = 0;
 
   virtual bool dirty (void) const = 0;
   virtual void clear_dirty (void) = 0;

--- a/src/wbs_impl.cxx
+++ b/src/wbs_impl.cxx
@@ -90,6 +90,22 @@ WBSImpl::indent (const Path & path)
   parent->indent_child (child_index);
 }
 
+void
+WBSImpl::unindent (const Path & path)
+{
+  assert (path.parts_length () > 1);
+
+  Task * parent = &m_root;
+  size_t child_index = path[path.parts_length () - 1];
+  size_t parent_index = path[path.parts_length () - 2];
+  for (auto index : path.parts ())
+  {
+    parent = parent->child (index);
+  }
+  parent = parent->parent ();
+  parent->unindent_child (child_index, parent_index);
+}
+
 NAMESPACE__THITTAM__END
 
 /*

--- a/src/wbs_impl.h
+++ b/src/wbs_impl.h
@@ -33,6 +33,7 @@ public:
   void add_child (const Path & parent_path);
   void add_sibling (const Path & path);
   void indent (const Path & path);
+  void unindent (const Path & path);
 
   bool dirty (void) const
   {


### PR DESCRIPTION
Currently there is a segfault when I try to unindent a node which is a parent as well as child. I tried to narrow down to the culprit being `Task::add_child_after`. It might be something else which I am not sure of.