### PR TITLE
get_task_at_level(path, level) can be used to get the task at a specific level

### DIFF
--- a/src/task.cxx
+++ b/src/task.cxx
@@ -52,7 +52,7 @@ Task::add_child_after (size_t index, std::unique_ptr<Task> && task)
   m_children_owned.insert (owned_it, std::move (task));
 
   task_raw->set_parent (this);
-  recompute_id_of_children (index + 1);
+  recompute_id_of_children ();
 }
 
 void

--- a/src/wbs_impl.cxx
+++ b/src/wbs_impl.cxx
@@ -54,7 +54,7 @@ void
 WBSImpl::add_child (const Path & path)
 {
   /* Find the parent */
-  auto parent = get_task_at_level (path, path.parts_length () - 1);
+  auto parent = get_task_at_level (path, path.parts_length ());
 
   /* Make a new node/task */
   auto task = std::make_unique<Task> ();

--- a/src/wbs_impl.cxx
+++ b/src/wbs_impl.cxx
@@ -39,35 +39,37 @@ WBSImpl::is_top_level (const Path & path) const
   return false;
 }
 
+Task *
+WBSImpl::get_task_at_level(const Path & path, size_t level)
+{
+  Task * parent = &m_root;
+  for (size_t i = 0; i < path.parts_length() and i < level; i++)
+  {
+    parent = parent->child (path[i]);
+  }
+  return parent;
+}
+
 void
-WBSImpl::add_child (const Path & parent_path)
+WBSImpl::add_child (const Path & path)
 {
   /* Find the parent */
-  Task * parent = &m_root;
-  for (auto index : parent_path.parts ())
-  {
-    parent = parent->child (index);
-  }
+  auto parent = get_task_at_level (path, path.parts_length () - 1);
+
+  /* Make a new node/task */
+  auto task = std::make_unique<Task> ();
 
   /* Add to tree */
-  auto task = std::make_unique<Task> ();
   parent->add_child (std::move (task));
 }
 
 void
-WBSImpl::add_sibling (const Path & sibling_path)
+WBSImpl::add_sibling (const Path & path)
 {
-  ASSERT ((sibling_path.parts_length () != 0), "Sibling path cannot be empty");
+  ASSERT ((path.parts_length () != 0), "Sibling path cannot be empty");
 
-  /* Find the sibling */
-  Task * sibling = &m_root;
-  size_t sibling_index = 0;
-  for (auto index : sibling_path.parts ())
-  {
-    sibling = sibling->child (index);
-    sibling_index = index;
-  }
-  auto parent = sibling->parent ();
+  auto parent = get_task_at_level (path, path.parts_length () - 1);
+  auto sibling_index = path[path.parts_length () - 1];
 
   auto task = std::make_unique<Task> ();
   parent->add_child_after (sibling_index, std::move (task));
@@ -79,14 +81,9 @@ WBSImpl::indent (const Path & path)
   assert (path.empty () == false);
   assert (path.last_part () != 0);
 
-  Task * parent = &m_root;
-  size_t child_index = 0;
-  for (auto index : path.parts ())
-  {
-    parent = parent->child (index);
-    child_index = index;
-  }
-  parent = parent->parent ();
+  auto parent = get_task_at_level (path, path.parts_length () - 1);
+  auto child_index = path[path.parts_length () - 1];
+
   parent->indent_child (child_index);
 }
 
@@ -95,14 +92,10 @@ WBSImpl::unindent (const Path & path)
 {
   assert (path.parts_length () > 1);
 
-  Task * parent = &m_root;
   size_t child_index = path[path.parts_length () - 1];
   size_t parent_index = path[path.parts_length () - 2];
-  for (auto index : path.parts ())
-  {
-    parent = parent->child (index);
-  }
-  parent = parent->parent ();
+  auto parent = get_task_at_level (path, path.parts_length () - 1);
+
   parent->unindent_child (child_index, parent_index);
 }
 

--- a/src/wbs_impl.h
+++ b/src/wbs_impl.h
@@ -35,6 +35,8 @@ public:
   void indent (const Path & path);
   void unindent (const Path & path);
 
+  Task *get_task_at_level(const Path & path, size_t level);
+
   bool dirty (void) const
   {
     return m_dirty;


### PR DESCRIPTION
This was necessary to make the code of add_{child|sibling} and {un}indent more simple and modular.

It was causing a segfault which I fixed but regular testing before merge is necessary. I have tested it and it works well enough for me.