### PR TITLE
field changes to resource and resource groups

### DIFF
--- a/src/main.cxx
+++ b/src/main.cxx
@@ -15,7 +15,6 @@
 int
 main (int argc, char ** argv)
 {
-  thittam::util::init_random ();
   auto app = std::make_shared<thittam::AppImpl> ();
   int ret = app->run (argc, argv);
   return ret;

--- a/src/resource-group.cxx
+++ b/src/resource-group.cxx
@@ -13,16 +13,30 @@
 
 NAMESPACE__THITTAM__START
 
-Resource &
-ResourceGroup::_get_resource (const int index)
+const Resource *
+ResourceGroup::get_resource (const std::string& id) const
 {
-  return *std::next(m_resources.begin (), index);
+  for (auto & it : m_resources)
+  {
+    if (it.id() == id)
+    {
+      return &it;
+    }
+  }
+  return NULL;
 }
 
-const Resource &
-ResourceGroup::get_resource (const int index) const
+Resource *
+ResourceGroup::get_resource_mutable (const std::string& id)
 {
-  return *std::next(m_resources.begin (), index);
+  for (auto & it : m_resources)
+  {
+    if (it.id() == id)
+    {
+      return &it;
+    }
+  }
+  return NULL;
 }
 
 void
@@ -30,19 +44,19 @@ ResourceGroup::renumber_ids (void)
 {
   for (auto & it : m_resources)
   {
-    id_counter++;
-    it.set_id(std::to_string(id_counter));
+    m_id_counter++;
+    it.set_id(std::to_string(m_id_counter));
   }
 }
 
 void
 ResourceGroup::create_resource_id (void)
 {
-  if (id_counter - m_resources.size() > SIZE_COUNTER_DIFFERENCE)
+  if (m_id_counter - m_resources.size() > SIZE_COUNTER_DIFFERENCE)
   {
     renumber_ids();
   }
-  id_counter++;
+  m_id_counter++;
 }
 
 bool
@@ -68,47 +82,10 @@ ResourceGroup::add_resource (const std::string & resource_name)
 
   Resource new_res;
   create_resource_id ();
-  new_res.set_id(std::to_string(id_counter));
+  new_res.set_id(std::to_string(m_id_counter));
   new_res.set_name(resource_name);
   m_resources.push_back(new_res);
   return true;
-}
-
-bool
-ResourceGroup::change_resource_name (
-  const int index,
-  const std::string & resource_name)
-{
-  if (is_unique_resource_name(resource_name))
-  {
-    ResourceGroup::_get_resource(index).Resource::set_name(resource_name);
-    return true;
-  }
-  return false;
-}
-
-void
-ResourceGroup::change_resource_long_name (
-  const int index,
-  const std::string & resource_long_name)
-{
-  ResourceGroup::_get_resource(index).Resource::set_long_name(resource_long_name);
-}
-
-void
-ResourceGroup::change_resource_cost (
-  const int index,
-  const float & resource_cost)
-{
-  ResourceGroup::_get_resource(index).Resource::set_cost(resource_cost);
-}
-
-void
-ResourceGroup::change_resource_description (
-  const int index,
-  const std::string & resource_description)
-{
-  ResourceGroup::_get_resource(index).Resource::set_description(resource_description);
 }
 
 NAMESPACE__THITTAM__END

--- a/src/resource-group.cxx
+++ b/src/resource-group.cxx
@@ -13,39 +13,6 @@
 
 NAMESPACE__THITTAM__START
 
-bool
-ResourceGroup::validate_resources_id (const std::string & resource_id)
-{
-  for (auto & it : m_resources)
-  {
-    if (it.id() == resource_id)
-    {
-      return false;
-    }
-  }
-  return true;
-}
-
-std::string
-ResourceGroup::generate_unique_resource_id (void)
-{
-  // In case number of resources is more than MOD_MAX
-  // generating unique id would not be possible
-  if (m_resources.size() < MOD_MAX)
-  {
-    unsigned int seeder = 0;
-    std::string id = std::to_string(util::generate_random_id());
-    for (; !ResourceGroup::validate_resources_id(id) ; )
-    {
-      id = std::to_string(util::generate_random_id() + seeder);
-      seeder++;
-    }
-    std::cout << "Executed " << seeder << " times\n\n";
-    return id;
-  }
-  return FAILED_TO_GENERATE_RANDOM_ID;
-}
-
 Resource &
 ResourceGroup::_get_resource (const int index)
 {
@@ -58,41 +25,74 @@ ResourceGroup::get_resource (const int index) const
   return *std::next(m_resources.begin (), index);
 }
 
-size_t
-ResourceGroup::add_resource (void)
+void
+ResourceGroup::renumber_ids (void)
 {
-  std::string id = ResourceGroup::generate_unique_resource_id();
-
-  if (id != FAILED_TO_GENERATE_RANDOM_ID)
+  for (auto & it : m_resources)
   {
-    Resource new_res = Resource();
-    new_res.Resource::set_id(id);
-    m_resources.push_back(new_res);
-    return m_resources.size() - 1;
+    id_counter++;
+    it.set_id(std::to_string(id_counter));
   }
+}
 
-  throw "Unable to generate id";
+void
+ResourceGroup::create_resource_id (void)
+{
+  if (id_counter - m_resources.size() > SIZE_COUNTER_DIFFERENCE)
+  {
+    renumber_ids();
+  }
+  id_counter++;
 }
 
 bool
-ResourceGroup::change_resource_id (
-  const int index,
-  const std::string & resource_id)
+ResourceGroup::is_unique_resource_name (const std::string & resource_name)
 {
-  if (ResourceGroup::validate_resources_id(resource_id))
+  for (auto & it : m_resources)
   {
-    ResourceGroup::_get_resource(index).Resource::set_id(resource_id);
+    if (it.name() == resource_name)
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool
+ResourceGroup::add_resource (const std::string & resource_name)
+{
+  if (!is_unique_resource_name(resource_name))
+  {
+    return false;
+  }
+
+  Resource new_res;
+  create_resource_id ();
+  new_res.set_id(std::to_string(id_counter));
+  new_res.set_name(resource_name);
+  m_resources.push_back(new_res);
+  return true;
+}
+
+bool
+ResourceGroup::change_resource_name (
+  const int index,
+  const std::string & resource_name)
+{
+  if (is_unique_resource_name(resource_name))
+  {
+    ResourceGroup::_get_resource(index).Resource::set_name(resource_name);
     return true;
   }
   return false;
 }
 
 void
-ResourceGroup::change_resource_name (
+ResourceGroup::change_resource_long_name (
   const int index,
-  const std::string & resource_name)
+  const std::string & resource_long_name)
 {
-  ResourceGroup::_get_resource(index).Resource::set_name(resource_name);
+  ResourceGroup::_get_resource(index).Resource::set_long_name(resource_long_name);
 }
 
 void
@@ -101,6 +101,14 @@ ResourceGroup::change_resource_cost (
   const float & resource_cost)
 {
   ResourceGroup::_get_resource(index).Resource::set_cost(resource_cost);
+}
+
+void
+ResourceGroup::change_resource_description (
+  const int index,
+  const std::string & resource_description)
+{
+  ResourceGroup::_get_resource(index).Resource::set_description(resource_description);
 }
 
 NAMESPACE__THITTAM__END

--- a/src/resource-group.h
+++ b/src/resource-group.h
@@ -54,15 +54,11 @@ public:
 
   bool add_resource (const std::string & resource_name);
 
-  bool change_resource_name (const int index, const std::string & resource_name);
-  void change_resource_long_name (const int index, const std::string & resource_long_name);
-  void change_resource_cost (const int index, const float & resource_cost);
-  void change_resource_description (const int index, const std::string & resource_description);
-
-  const Resource & get_resource (const int index) const;
+  const Resource * get_resource (const std::string& id) const;
+  Resource * get_resource_mutable (const std::string& id);
 
 private:
-  static unsigned int id_counter;
+  static unsigned int m_id_counter;
   std::string m_id;
   // Hidden from user. NOTNULL & UNIQUE
   
@@ -72,7 +68,6 @@ private:
   std::string m_description;
   std::list <Resource> m_resources;
 
-  Resource & _get_resource (const int index);
   void create_resource_id (void);
   void renumber_ids (void);
   bool is_unique_resource_name (const std::string & resource_name);

--- a/src/resource-group.h
+++ b/src/resource-group.h
@@ -17,8 +17,6 @@
 #include "resource.h"
 #include "util.h"
 
-#define FAILED_TO_GENERATE_RANDOM_ID "FAILED"
-
 NAMESPACE__THITTAM__START
 
 class ResourceGroup
@@ -34,11 +32,14 @@ public:
     return m_name;
   }
 
+  const std::string & description () const
+  {
+    return m_description;
+  }
+
   void set_id (const std::string & id)
   {
-    if (id.length() <= 6) {
-      m_id = id;
-    }
+    m_id = id;
   }
 
   void set_name (const std::string & name)
@@ -46,22 +47,35 @@ public:
     m_name = name;
   }
 
-  size_t add_resource (void);
+  void set_description (const std::string & description)
+  {
+    m_description = description;
+  }
 
-  bool change_resource_id (const int index, const std::string & resource_id);
-  void change_resource_name (const int index, const std::string & resource_name);
+  bool add_resource (const std::string & resource_name);
+
+  bool change_resource_name (const int index, const std::string & resource_name);
+  void change_resource_long_name (const int index, const std::string & resource_long_name);
   void change_resource_cost (const int index, const float & resource_cost);
+  void change_resource_description (const int index, const std::string & resource_description);
 
   const Resource & get_resource (const int index) const;
 
 private:
+  static unsigned int id_counter;
   std::string m_id;
-  std::string m_name = "group name";
+  // Hidden from user. NOTNULL & UNIQUE
+  
+  std::string m_name;
+  // NOTNULL & UNIQUE
+
+  std::string m_description;
   std::list <Resource> m_resources;
 
   Resource & _get_resource (const int index);
-  bool validate_resources_id (const std::string & resource_id);
-  std::string generate_unique_resource_id (void);
+  void create_resource_id (void);
+  void renumber_ids (void);
+  bool is_unique_resource_name (const std::string & resource_name);
 };
 
 NAMESPACE__THITTAM__END

--- a/src/resource-manager.cxx
+++ b/src/resource-manager.cxx
@@ -13,29 +13,43 @@
 
 NAMESPACE__THITTAM__START
 
-ResourceGroup &
-ResourceManager::_get_group (const std::string & id)
+
+const Resource *
+ResourceManager::get_resource (const std::string & group_id, const std::string & resource_id) const
+{
+  return get_resource_group(group_id)->ResourceGroup::get_resource(resource_id);
+}
+
+Resource *
+ResourceManager::get_resource_mutable (const std::string & group_id, const std::string & resource_id)
+{
+  return get_resource_group_mutable(group_id)->ResourceGroup::get_resource_mutable(resource_id);
+}
+
+const ResourceGroup *
+ResourceManager::get_resource_group (const std::string & id) const
 {
   for (auto & it : m_resource_groups)
   {
     if (it.id() == id)
     {
-      return it;
+      return &it;
     }
   }
-  throw ("Invalid Id");
+  return NULL;
 }
 
-ResourceGroup &
-ResourceManager::_get_group (const int index)
+ResourceGroup *
+ResourceManager::get_resource_group_mutable (const std::string & id)
 {
-  return *std::next(m_resource_groups.begin (), index);
-}
-
-const ResourceGroup &
-ResourceManager::get_group (const int index) const
-{
-  return *std::next(m_resource_groups.begin (), index);
+  for (auto & it : m_resource_groups)
+  {
+    if (it.id() == id)
+    {
+      return &it;
+    }
+  }
+  return NULL;
 }
 
 void
@@ -43,19 +57,19 @@ ResourceManager::renumber_ids (void)
 {
   for (auto & it : m_resource_groups)
   {
-    id_counter++;
-    it.set_id(std::to_string(id_counter));
+    m_id_counter++;
+    it.set_id(std::to_string(m_id_counter));
   }
 }
 
 void
 ResourceManager::create_group_id (void)
 {
-  if (id_counter - m_resource_groups.size() > SIZE_COUNTER_DIFFERENCE)
+  if (m_id_counter - m_resource_groups.size() > SIZE_COUNTER_DIFFERENCE)
   {
     renumber_ids();
   }
-  id_counter++;
+  m_id_counter++;
 }
 
 bool
@@ -81,113 +95,16 @@ ResourceManager::add_group (const std::string & group_name)
 
   ResourceGroup new_group;
   create_group_id ();
-  new_group.set_id(std::to_string(id_counter));
+  new_group.set_id(std::to_string(m_id_counter));
   new_group.set_name(group_name);
   m_resource_groups.push_back(new_group);
   return true;
 }
 
-const std::string &
-ResourceManager::get_group_id (const int index) const
-{
-  return get_group(index).id();
-}
-
-const std::string &
-ResourceManager::get_group_name (const int index) const
-{
-  return get_group(index).name();
-}
-
-const std::string &
-ResourceManager::get_group_description (const int index) const
-{
-  return get_group(index).description();
-}
-
 bool
-ResourceManager::change_group_name (const int index, const std::string & group_name)
+ResourceManager::add_resource (const std::string & group_id, const std::string & resource_name)
 {
-  if (is_unique_group_name(group_name))
-  {
-    ResourceManager::_get_group(index).ResourceGroup::set_name(group_name);
-    return true;
-  }
-  return false;
-}
-
-void
-ResourceManager::change_group_description (const int index, const std::string & group_description)
-{
-  ResourceManager::_get_group(index).ResourceGroup::set_description(group_description);
-}
-
-
-
-const Resource &
-ResourceManager::get_resource (const int group_i, const int resource_i) const
-{
-  return get_group (group_i).get_resource (resource_i);
-}
-
-bool
-ResourceManager::add_resource (const int index, const std::string & resource_name)
-{
-  return (ResourceManager::_get_group(index).ResourceGroup::add_resource(resource_name));
-}
-
-const std::string &
-ResourceManager::get_resource_id (const int group_index, const int resource_index) const
-{
-  return get_resource(group_index, resource_index).id();
-}
-
-const std::string &
-ResourceManager::get_resource_name (const int group_index, const int resource_index) const
-{
-  return get_resource(group_index, resource_index).name();
-}
-
-const std::string &
-ResourceManager::get_resource_long_name (const int group_index, const int resource_index) const
-{
-  return get_resource(group_index, resource_index).long_name();
-}
-
-const float 
-ResourceManager::get_resource_cost (const int group_index, const int resource_index) const
-{
-  return get_resource(group_index, resource_index).cost();
-}
-
-const std::string &
-ResourceManager::get_resource_description (const int group_index, const int resource_index) const
-{
-  return get_resource(group_index, resource_index).description();
-}
-
-bool
-ResourceManager::change_resource_name (const int group_index, const int resource_index, const std::string & resource_name)
-{
-  ResourceManager::_get_group(group_index).ResourceGroup::change_resource_name(resource_index, resource_name);
-}
-
-void
-ResourceManager::change_resource_long_name (const int group_index, const int resource_index, const std::string & resource_long_name)
-{
-  ResourceManager::_get_group(group_index).ResourceGroup::change_resource_long_name(resource_index, resource_long_name);
-}
-
-void
-ResourceManager::change_resource_cost (const int group_index, const int resource_index, const float & resource_cost)
-{
-  ResourceManager::_get_group(group_index).ResourceGroup::change_resource_cost(resource_index, resource_cost);
-}
-
-void
-ResourceManager::change_resource_description (const int group_index, const int resource_index, const std::string & resource_description)
-{
-  ResourceManager::_get_group(group_index).ResourceGroup::change_resource_description(resource_index, resource_description);
+  return get_resource_group_mutable(group_id)->add_resource(resource_name);
 }
 
 void

--- a/src/resource-manager.cxx
+++ b/src/resource-manager.cxx
@@ -13,39 +13,6 @@
 
 NAMESPACE__THITTAM__START
 
-bool
-ResourceManager::validate_group_id (const std::string & group_id)
-{
-  for (auto & it : m_resource_groups)
-  {
-    if (it.id() == group_id)
-    {
-      return false;
-    }
-  }
-  return true;
-}
-
-std::string
-ResourceManager::generate_unique_group_id (void)
-{
-  // In case number of groups is more than MOD_MAX
-  // generating unique id would not be possible
-  if (m_resource_groups.size() < MOD_MAX)
-  {
-    unsigned int seeder = 0;
-    std::string id = std::to_string(util::generate_random_id());
-
-    for (; !ResourceManager::validate_group_id(id) ; )
-    {
-      id = std::to_string(util::generate_random_id() + seeder);
-      seeder++;
-    }
-    return id;
-  }
-  return FAILED_TO_GENERATE_RANDOM_ID;
-}
-
 ResourceGroup &
 ResourceManager::_get_group (const std::string & id)
 {
@@ -71,98 +38,156 @@ ResourceManager::get_group (const int index) const
   return *std::next(m_resource_groups.begin (), index);
 }
 
-const Resource &
-ResourceManager::get_resource (const int group_i, const int resource_i) const
+void
+ResourceManager::renumber_ids (void)
 {
-  return get_group (group_i).get_resource (resource_i);
+  for (auto & it : m_resource_groups)
+  {
+    id_counter++;
+    it.set_id(std::to_string(id_counter));
+  }
 }
 
-const std::string & ResourceManager::get_group_id (const int index) const
+void
+ResourceManager::create_group_id (void)
+{
+  if (id_counter - m_resource_groups.size() > SIZE_COUNTER_DIFFERENCE)
+  {
+    renumber_ids();
+  }
+  id_counter++;
+}
+
+bool
+ResourceManager::is_unique_group_name (const std::string & group_name)
+{
+  for (auto & it : m_resource_groups)
+  {
+    if (it.name() == group_name)
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool
+ResourceManager::add_group (const std::string & group_name)
+{
+  if (!is_unique_group_name(group_name))
+  {
+    return false;
+  }
+
+  ResourceGroup new_group;
+  create_group_id ();
+  new_group.set_id(std::to_string(id_counter));
+  new_group.set_name(group_name);
+  m_resource_groups.push_back(new_group);
+  return true;
+}
+
+const std::string &
+ResourceManager::get_group_id (const int index) const
 {
   return get_group(index).id();
 }
 
-const std::string & ResourceManager::get_group_name (const int index) const
+const std::string &
+ResourceManager::get_group_name (const int index) const
 {
   return get_group(index).name();
 }
 
-const std::string & ResourceManager::get_resource_id (
-  const int group_index,
-  const int resource_index) const
+const std::string &
+ResourceManager::get_group_description (const int index) const
 {
-  return get_resource(group_index, resource_index).id();
-}
-
-const std::string & ResourceManager::get_resource_name (
-  const int group_index,
-  const int resource_index) const
-{
-  return get_resource(group_index, resource_index).name();
-}
-
-const float ResourceManager::get_resource_cost (
-  const int group_index,
-  const int resource_index) const
-{
-  return get_resource(group_index, resource_index).cost();
-}
-
-size_t
-ResourceManager::add_group (void)
-{
-  std::string id = ResourceManager::generate_unique_group_id();
-  if (id != FAILED_TO_GENERATE_RANDOM_ID)
-  {
-    ResourceGroup new_res_group = ResourceGroup();
-    new_res_group.ResourceGroup::set_id(id);
-    m_resource_groups.push_back(new_res_group);
-    return m_resource_groups.size () - 1;
-  }
-
-  throw "Unable to set unique id";
-}
-
-size_t
-ResourceManager::add_resource (const int index)
-{
-  return (ResourceManager::_get_group(index).ResourceGroup::add_resource());
+  return get_group(index).description();
 }
 
 bool
-ResourceManager::change_group_id (const int index, const std::string & group_id)
+ResourceManager::change_group_name (const int index, const std::string & group_name)
 {
-
-  if (ResourceManager::validate_group_id(group_id))
+  if (is_unique_group_name(group_name))
   {
-    ResourceManager::_get_group(index).ResourceGroup::set_id(group_id);
+    ResourceManager::_get_group(index).ResourceGroup::set_name(group_name);
     return true;
   }
   return false;
 }
 
 void
-ResourceManager::change_group_name (const int index, const std::string & group_name)
+ResourceManager::change_group_description (const int index, const std::string & group_description)
 {
-  ResourceManager::_get_group(index).ResourceGroup::set_name(group_name);
+  ResourceManager::_get_group(index).ResourceGroup::set_description(group_description);
+}
+
+
+
+const Resource &
+ResourceManager::get_resource (const int group_i, const int resource_i) const
+{
+  return get_group (group_i).get_resource (resource_i);
 }
 
 bool
-ResourceManager::change_resource_id (const int group_index, const int resource_index, const std::string & resource_id)
+ResourceManager::add_resource (const int index, const std::string & resource_name)
 {
-  return ResourceManager::_get_group(group_index).ResourceGroup::change_resource_id(resource_index, resource_id);
+  return (ResourceManager::_get_group(index).ResourceGroup::add_resource(resource_name));
 }
 
-void
+const std::string &
+ResourceManager::get_resource_id (const int group_index, const int resource_index) const
+{
+  return get_resource(group_index, resource_index).id();
+}
+
+const std::string &
+ResourceManager::get_resource_name (const int group_index, const int resource_index) const
+{
+  return get_resource(group_index, resource_index).name();
+}
+
+const std::string &
+ResourceManager::get_resource_long_name (const int group_index, const int resource_index) const
+{
+  return get_resource(group_index, resource_index).long_name();
+}
+
+const float 
+ResourceManager::get_resource_cost (const int group_index, const int resource_index) const
+{
+  return get_resource(group_index, resource_index).cost();
+}
+
+const std::string &
+ResourceManager::get_resource_description (const int group_index, const int resource_index) const
+{
+  return get_resource(group_index, resource_index).description();
+}
+
+bool
 ResourceManager::change_resource_name (const int group_index, const int resource_index, const std::string & resource_name)
 {
   ResourceManager::_get_group(group_index).ResourceGroup::change_resource_name(resource_index, resource_name);
 }
 
 void
+ResourceManager::change_resource_long_name (const int group_index, const int resource_index, const std::string & resource_long_name)
+{
+  ResourceManager::_get_group(group_index).ResourceGroup::change_resource_long_name(resource_index, resource_long_name);
+}
+
+void
 ResourceManager::change_resource_cost (const int group_index, const int resource_index, const float & resource_cost)
 {
   ResourceManager::_get_group(group_index).ResourceGroup::change_resource_cost(resource_index, resource_cost);
+}
+
+void
+ResourceManager::change_resource_description (const int group_index, const int resource_index, const std::string & resource_description)
+{
+  ResourceManager::_get_group(group_index).ResourceGroup::change_resource_description(resource_index, resource_description);
 }
 
 void

--- a/src/resource-manager.h
+++ b/src/resource-manager.h
@@ -23,36 +23,19 @@ class ResourceManager
 {
 public:
   bool add_group (const std::string & group_name);
-  const std::string & get_group_id (const int) const;
-  const std::string & get_group_name (const int) const;
-  const std::string & get_group_description (const int) const;
-  bool change_group_name (const int index, const std::string & group_name);
-  void change_group_description (const int index, const std::string & group_description);
+  bool add_resource (const std::string & group_id, const std::string & resource_name);
 
-  bool add_resource (const int index, const std::string & resource_name);
-  const std::string & get_resource_id (const int, const int) const;
-  const std::string & get_resource_name (const int, const int) const;
-  const std::string & get_resource_long_name (const int, const int) const;
-  const float get_resource_cost (const int, const int) const;
-  const std::string & get_resource_description (const int, const int) const;
-
-  bool change_resource_name (const int, const int, const std::string &);
-  void change_resource_long_name (const int, const int, const std::string &);
-  void change_resource_cost (const int, const int, const float &);
-  void change_resource_description (const int, const int, const std::string &);
-
-  const ResourceGroup & get_group (const int index) const;
-  const Resource & get_resource (const int, const int) const;
+  const Resource * get_resource (const std::string & group_id, const std::string & resource_id) const;
+  Resource * get_resource_mutable (const std::string & group_id, const std::string & resource_id);
+  const ResourceGroup * get_resource_group (const std::string &id) const;
+  ResourceGroup * get_resource_group_mutable (const std::string &id);
 
   // WIP
   void generate_json (void);
 
 private:
-  static unsigned int id_counter;
+  static unsigned int m_id_counter;
   std::list <ResourceGroup> m_resource_groups;
-
-  ResourceGroup & _get_group (const std::string & id);
-  ResourceGroup & _get_group (const int index);
 
   void create_group_id (void);
   void renumber_ids (void);

--- a/src/resource-manager.h
+++ b/src/resource-manager.h
@@ -22,22 +22,24 @@ NAMESPACE__THITTAM__START
 class ResourceManager
 {
 public:
-  bool change_group_id (const int index, const std::string & group_id);
-  void change_group_name (const int index, const std::string & group_name);
-
-  size_t add_group (void);
-  size_t add_resource (const int index);
-
+  bool add_group (const std::string & group_name);
   const std::string & get_group_id (const int) const;
   const std::string & get_group_name (const int) const;
+  const std::string & get_group_description (const int) const;
+  bool change_group_name (const int index, const std::string & group_name);
+  void change_group_description (const int index, const std::string & group_description);
 
+  bool add_resource (const int index, const std::string & resource_name);
   const std::string & get_resource_id (const int, const int) const;
   const std::string & get_resource_name (const int, const int) const;
+  const std::string & get_resource_long_name (const int, const int) const;
   const float get_resource_cost (const int, const int) const;
+  const std::string & get_resource_description (const int, const int) const;
 
-  bool change_resource_id (const int, const int, const std::string &);
-  void change_resource_name (const int, const int, const std::string &);
+  bool change_resource_name (const int, const int, const std::string &);
+  void change_resource_long_name (const int, const int, const std::string &);
   void change_resource_cost (const int, const int, const float &);
+  void change_resource_description (const int, const int, const std::string &);
 
   const ResourceGroup & get_group (const int index) const;
   const Resource & get_resource (const int, const int) const;
@@ -46,12 +48,15 @@ public:
   void generate_json (void);
 
 private:
+  static unsigned int id_counter;
   std::list <ResourceGroup> m_resource_groups;
 
   ResourceGroup & _get_group (const std::string & id);
   ResourceGroup & _get_group (const int index);
-  bool validate_group_id (const std::string & group_id);
-  std::string generate_unique_group_id (void);
+
+  void create_group_id (void);
+  void renumber_ids (void);
+  bool is_unique_group_name (const std::string & group_name);
 };
 
 NAMESPACE__THITTAM__END

--- a/src/resource.h
+++ b/src/resource.h
@@ -16,6 +16,8 @@
 
 NAMESPACE__THITTAM__START
 
+#define SIZE_COUNTER_DIFFERENCE 100
+
 class Resource
 {
 public:
@@ -29,16 +31,24 @@ public:
     return m_name;
   }
 
+  const std::string & long_name (void) const
+  {
+    return m_long_name;
+  }
+
   const float & cost (void) const
   {
     return m_cost;
   }
 
+  const std::string & description (void) const
+  {
+    return m_description;
+  }
+
   void set_id (const std::string & id)
   {
-    if (id.length() <= 6){
-      m_id = id;
-    }
+    m_id = id;
   }
 
   void set_name (const std::string & name)
@@ -46,15 +56,30 @@ public:
     m_name = name;
   }
 
+  void set_long_name (const std::string & long_name)
+  {
+    m_long_name = long_name;
+  }
+
   void set_cost (const float & cost)
   {
     m_cost = cost;
   }
 
+  void set_description (const std::string & description)
+  {
+    m_description = description;
+  }
+
 private:
   std::string m_id;
-  std::string m_name = "resource name";
-  float m_cost = 10;
+  // Hidden from user. NOTNULL & UNIQUE
+  std::string m_name;
+  // NOTNULL & UNIQUE
+
+  std::string m_long_name;
+  float m_cost;
+  std::string m_description;
 };
 
 NAMESPACE__THITTAM__END

--- a/src/resources-controller_impl.cxx
+++ b/src/resources-controller_impl.cxx
@@ -52,45 +52,45 @@ void ResourcesControllerImpl::view_node_changed (
     return;
   }
 
-  if (m_view->selected_is_group ())
-  {
-    if (m_rm->change_group_id (path[0], m_view->get_id (row)))
-    {
-      m_view->set_id (row, m_rm->get_group_id (path[0]));
-    }
-    m_rm->change_group_name (path[0], m_view->get_name (row));
-  }
-  else if (path.size () == 2)
-  {
-    if (m_rm->change_resource_id (path[0], path[1], m_view->get_id (row)))
-    {
-      m_view->set_id (row, m_rm->get_resource_id (path[0], path[1]));
-    }
-    m_rm->change_resource_name (path[0], path[1], m_view->get_name (row));
-    m_rm->change_resource_cost (path[0], path[1], m_view->get_cost (row));
-  }
+  // if (m_view->selected_is_group ())
+  // {
+  //   if (m_rm->change_group_id (path[0], m_view->get_id (row)))
+  //   {
+  //     m_view->set_id (row, m_rm->get_group_id (path[0]));
+  //   }
+  //   m_rm->change_group_name (path[0], m_view->get_name (row));
+  // }
+  // else if (path.size () == 2)
+  // {
+  //   if (m_rm->change_resource_id (path[0], path[1], m_view->get_id (row)))
+  //   {
+  //     m_view->set_id (row, m_rm->get_resource_id (path[0], path[1]));
+  //   }
+  //   m_rm->change_resource_name (path[0], path[1], m_view->get_name (row));
+  //   m_rm->change_resource_cost (path[0], path[1], m_view->get_cost (row));
+  // }
 }
 
 void ResourcesControllerImpl::view_add_resource_clicked (void)
 {
-  int gi = group_index;
-  if (gi == -1)
-  {
-    return;
-  }
-  size_t ri = m_rm->add_resource (gi);
-  m_view->add_resource (
-    gi,
-    m_rm->get_resource_id (gi, ri),
-    m_rm->get_resource_name (gi, ri),
-    m_rm->get_resource_cost (gi, ri));
+  // int gi = group_index;
+  // if (gi == -1)
+  // {
+  //   return;
+  // }
+  // size_t ri = m_rm->add_resource (gi);
+  // m_view->add_resource (
+  //   gi,
+  //   m_rm->get_resource_id (gi, ri),
+  //   m_rm->get_resource_name (gi, ri),
+  //   m_rm->get_resource_cost (gi, ri));
 }
 
 void ResourcesControllerImpl::view_add_group_clicked (void)
 {
-  Log_I << "Adding new group";
-  size_t gi = m_rm->add_group ();
-  m_view->add_group (m_rm->get_group_id (gi), m_rm->get_group_name (gi));
+  // Log_I << "Adding new group";
+  // size_t gi = m_rm->add_group ();
+  // m_view->add_group (m_rm->get_group_id (gi), m_rm->get_group_name (gi));
 }
 
 void ResourcesControllerImpl::view_delete_clicked (void)

--- a/src/util.cxx
+++ b/src/util.cxx
@@ -19,20 +19,6 @@ int effort_str_to_minutes (
   return 2400;
 }
 
-void init_random (void)
-{
-  srand((unsigned)time(NULL));
-}
-
-unsigned int
-generate_random_id ()
-{
-  // For 6 digit random number.
-  srand(time(NULL));
-  unsigned int number = rand() % MOD_MAX;
-  return number;
-}
-
 NAMESPACE__THITTAM_UTIL__END
 
 /*

--- a/src/util.h
+++ b/src/util.h
@@ -14,21 +14,14 @@
 #include <cstdlib>
 #include <ctime>
 
-#define MOD_MAX 999999
-
 #define NAMESPACE__THITTAM_UTIL__START namespace thittam { namespace util {
 #define NAMESPACE__THITTAM_UTIL__END } }
 
 NAMESPACE__THITTAM_UTIL__START
 
-void init_random (void);
-
 int effort_str_to_minutes (
   const std::string & effort, int working_days_per_week,
   int working_hours_per_day);
-
-// generates 6 digit random number string for resource and group id.
-unsigned int generate_random_id ();
 
 NAMESPACE__THITTAM_UTIL__END
 


### PR DESCRIPTION
Issue #38 and #39 are resolved here.

This commit onwards: no public method can change resource or group id.
So, any call to public functions like change_*_id () must be removed. (see resource controller)